### PR TITLE
Render URLs in location fields as clickable links

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,10 @@ If you want to use it with an older version of logseq, change your settings file
     -  `{End}`
     -  `{Date}`
     -  `{Location}`
+    -  `{RawLocation}`
 - Templates are the format by which the events are inserted
     -  You can define templates in settings
+- `{Location}` will collapse URLs (e.g. for videoconferencing) into short clickable links by default (e.g. "https://videocall.example.com/j/123456789?pwd=abcdefghijklmnopqrstuvwxyz or Room 101" will be rendered as "videocall.example.com/... or Room 101"), while RawLocation will preserve the original text.
 - Difference between `template` and `templateline2`
 <img width="993" alt="Screen Shot 2022-01-28 at 3 05 54 PM" src="https://user-images.githubusercontent.com/80150109/151536767-c4ca96aa-a57c-4ee6-9c7b-ee36b3d448ce.png">
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logseq-calendars-plugin",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Import GCal, iCloud,and Outlook calendars to your logseq daily note",
   "main": "dist/index.html",
   "targets": {
@@ -21,7 +21,9 @@
     "moment": "^2.29.3",
     "moment-timezone": "^0.5.34",
     "node-ical": "^0.14.1",
-    "tailwind": "^4.0.0"
+    "re2": "^1.17.7",
+    "tailwind": "^4.0.0",
+    "url-regex-safe": "^3.0.0"
   },
   "logseq": {
     "id": "logseq-calendars-plugin",


### PR DESCRIPTION
Currently, links (esp. teleconference links) in imported calendar event locations are not clickable, and are shown in full-length form, which clutters up the journal page with conference IDs and passphrases (and may be a security risk when sharing screens). This PR addresses that by rendering the links in short, clickable form.

This PR does not include changes to the lockfile, etc. for ease of review; they can be generated with `yarn add url-regex-safe re2` (the only additional dependencies added).